### PR TITLE
Upgrade Node.js on Lambda to `v22`

### DIFF
--- a/infra/aws/lambda.ts
+++ b/infra/aws/lambda.ts
@@ -78,7 +78,7 @@ export const lambdaS3Policy = new aws.iam.RolePolicy('lambda-s3-policy', {
 
 // Lambda function
 export const boltLambda = new aws.lambda.Function('bolt-lambda', {
-  runtime: aws.lambda.Runtime.NodeJS20dX,
+  runtime: aws.lambda.Runtime.NodeJS24dX,
   handler: 'index.handler',
   role: lambdaRole.arn,
   code: new pulumi.asset.AssetArchive({


### PR DESCRIPTION
Because `v20` wil be EOL in April 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lambda function runtime to NodeJS24dX for improved performance and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->