### PR TITLE
Release for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v0.1.5](https://github.com/Rindrics/slackmail/compare/v0.1.4...v0.1.5) - 2026-01-09
+- Setup Sentry for production by @Rindrics in https://github.com/Rindrics/slackmail/pull/64
+- Handle Slack error to know what occurs by @Rindrics in https://github.com/Rindrics/slackmail/pull/66
+- feat: post long text as file by @Rindrics in https://github.com/Rindrics/slackmail/pull/71
+- feat: post file as thread by @Rindrics in https://github.com/Rindrics/slackmail/pull/72
+- feat: provide mail sending functionality by @Rindrics in https://github.com/Rindrics/slackmail/pull/74
+- fix: correct mention parsing by @Rindrics in https://github.com/Rindrics/slackmail/pull/75
+- build: improve git hooks by @Rindrics in https://github.com/Rindrics/slackmail/pull/77
+- feat: handle Slack event to send mail by @Rindrics in https://github.com/Rindrics/slackmail/pull/76
+- chore: add logs by @Rindrics in https://github.com/Rindrics/slackmail/pull/78
+- chore: add logging by @Rindrics in https://github.com/Rindrics/slackmail/pull/79
+- fix: correct URL match pattern by @Rindrics in https://github.com/Rindrics/slackmail/pull/80
+- fix: parse <mailto:> format addres by @Rindrics in https://github.com/Rindrics/slackmail/pull/81
+- fix: allow sendMail permission by @Rindrics in https://github.com/Rindrics/slackmail/pull/82
+- feat: avoid repeated sending by @Rindrics in https://github.com/Rindrics/slackmail/pull/83
+- feat: configure MAIL FROM by @Rindrics in https://github.com/Rindrics/slackmail/pull/84
+- Bump @aws-sdk/client-s3 from 3.956.0 to 3.962.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/68
+- Bump @pulumi/pulumi from 3.213.0 to 3.214.1 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/70
+- Bump @biomejs/biome from 2.3.10 to 2.3.11 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/69
+- feat: allow bot mention after message URL by @Rindrics in https://github.com/Rindrics/slackmail/pull/85
+
 ## [v0.1.5](https://github.com/Rindrics/slackmail/compare/v0.1.4...v0.1.5) - 2026-01-06
 - Setup Sentry for production by @Rindrics in https://github.com/Rindrics/slackmail/pull/64
 - Handle Slack error to know what occurs by @Rindrics in https://github.com/Rindrics/slackmail/pull/66


### PR DESCRIPTION
This pull request is for the next release as v0.1.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Setup Sentry for production by @Rindrics in https://github.com/Rindrics/slackmail/pull/64
* Handle Slack error to know what occurs by @Rindrics in https://github.com/Rindrics/slackmail/pull/66
* feat: post long text as file by @Rindrics in https://github.com/Rindrics/slackmail/pull/71
* feat: post file as thread by @Rindrics in https://github.com/Rindrics/slackmail/pull/72
* feat: provide mail sending functionality by @Rindrics in https://github.com/Rindrics/slackmail/pull/74
* fix: correct mention parsing by @Rindrics in https://github.com/Rindrics/slackmail/pull/75
* build: improve git hooks by @Rindrics in https://github.com/Rindrics/slackmail/pull/77
* feat: handle Slack event to send mail by @Rindrics in https://github.com/Rindrics/slackmail/pull/76
* chore: add logs by @Rindrics in https://github.com/Rindrics/slackmail/pull/78
* chore: add logging by @Rindrics in https://github.com/Rindrics/slackmail/pull/79
* fix: correct URL match pattern by @Rindrics in https://github.com/Rindrics/slackmail/pull/80
* fix: parse <mailto:> format addres by @Rindrics in https://github.com/Rindrics/slackmail/pull/81
* fix: allow sendMail permission by @Rindrics in https://github.com/Rindrics/slackmail/pull/82
* feat: avoid repeated sending by @Rindrics in https://github.com/Rindrics/slackmail/pull/83
* feat: configure MAIL FROM by @Rindrics in https://github.com/Rindrics/slackmail/pull/84
* Bump @aws-sdk/client-s3 from 3.956.0 to 3.962.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/68
* Bump @pulumi/pulumi from 3.213.0 to 3.214.1 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/70
* Bump @biomejs/biome from 2.3.10 to 2.3.11 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/69
* feat: allow bot mention after message URL by @Rindrics in https://github.com/Rindrics/slackmail/pull/85


**Full Changelog**: https://github.com/Rindrics/slackmail/compare/v0.1.4...tagpr-from-v0.1.4