### PR TITLE
fix: correct URL match pattern

### DIFF
--- a/packages/core/src/presentation/slackApp.ts
+++ b/packages/core/src/presentation/slackApp.ts
@@ -387,13 +387,18 @@ export function registerMailSendingListeners(
   });
 
   // Handle "@bot <message_url>" - fetch, parse, confirm, and send email
-  // Slack mentions are formatted as <@USERID>, not @username
+  // Slack mentions are formatted as <@USERID>, URLs are wrapped in <URL> or <URL|text>
   app.message(
-    /<@[A-Z0-9]+>\s+(https:\/\/[^\s]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+)/i,
+    /<@[A-Z0-9]+>\s+<(https:\/\/[^|>\s]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+)/i,
     async ({ message, say, client }) => {
+      console.log(
+        '[Bolt] Matched URL pattern, message:',
+        JSON.stringify(message, null, 2),
+      );
       try {
+        // Slack wraps URLs in <URL> or <URL|display_text> format
         const match = (message as { text?: string }).text?.match(
-          /<@[A-Z0-9]+>\s+(https:\/\/[^\s]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+)/i,
+          /<@[A-Z0-9]+>\s+<(https:\/\/[^|>\s]+\.slack\.com\/archives\/[A-Z0-9]+\/p\d+)/i,
         );
 
         if (!match || !match[1]) {


### PR DESCRIPTION
### **User description**
- doing #12


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects URL pattern matching for Slack message links

- Updates regex to handle Slack's URL wrapping format

- Adds logging for debugging matched URL patterns

- Updates comment to reflect actual URL format


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Pattern<br/>unwrapped URLs"] -->|"Fix to handle<br/>wrapped format"| B["New Pattern<br/>URLs in &lt;URL&gt;"]
  B --> C["Regex with<br/>angle brackets"]
  C --> D["Logging added<br/>for debugging"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>slackApp.ts</strong><dd><code>Fix URL pattern matching for Slack wrapped URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/presentation/slackApp.ts

<ul><li>Updated regex pattern to match Slack's URL wrapping format <code><URL></code> or <code><URL|text></code><br> <li> Changed pattern from <code>(https://...)</code> to <code><(https://[^|>\s]+...)</code> to capture wrapped URLs<br> <li> Added console logging to debug matched URL patterns with full message <br>context<br> <li> Updated comment to clarify that URLs are wrapped in angle brackets by <br>Slack</ul>


</details>


  </td>
  <td><a href="https://github.com/Rindrics/slackmail/pull/80/files#diff-ba5c7d824f90a3f3cb25f9ca351a50c041a7deb70b660a47ae120ec89775e564">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack URL parsing to correctly handle message URLs wrapped in angle brackets, aligning with Slack's native formatting standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->