### PR TITLE
Release for v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.1.6](https://github.com/Rindrics/slackmail/compare/v0.1.5...v0.1.6) - 2026-02-25
+- build(deps-dev): bump vite-tsconfig-paths from 6.0.3 to 6.0.4 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/89
+- chore: enhance Husky hooks with comprehensive validation by @Rindrics in https://github.com/Rindrics/slackmail/pull/93
+- feat: support single-user- multi-domain- usecase by @Rindrics in https://github.com/Rindrics/slackmail/pull/92
+- Revert "feat: support single-user- multi-domain- usecase" by @Rindrics in https://github.com/Rindrics/slackmail/pull/95
+- ci: resolve AWS auth error for dependabot by @Rindrics in https://github.com/Rindrics/slackmail/pull/97
+- build(deps-dev): bump @types/nodemailer from 7.0.4 to 7.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/87
+- build(deps-dev): bump @pulumi/aws from 7.15.0 to 7.16.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/90
+- build(deps): bump @aws-sdk/client-sesv2 from 3.964.0 to 3.966.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/86
+- docs: update user instructions by @Rindrics in https://github.com/Rindrics/slackmail/pull/96
+- build(deps-dev): bump @types/node from 25.0.3 to 25.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/88
+- build(deps-dev): bump @biomejs/biome from 2.3.11 to 2.3.15 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/99
+- build(deps): bump mailparser from 3.9.1 to 3.9.3 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/102
+- build(deps-dev): bump dotenv from 17.2.3 to 17.3.1 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/101
+
 ## [v0.1.5](https://github.com/Rindrics/slackmail/compare/v0.1.4...v0.1.5) - 2026-01-09
 - Setup Sentry for production by @Rindrics in https://github.com/Rindrics/slackmail/pull/64
 - Handle Slack error to know what occurs by @Rindrics in https://github.com/Rindrics/slackmail/pull/66

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.1.6](https://github.com/Rindrics/slackmail/compare/v0.1.5...v0.1.6) - 2026-05-05
+- build(deps-dev): bump vite-tsconfig-paths from 6.0.3 to 6.0.4 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/89
+- chore: enhance Husky hooks with comprehensive validation by @Rindrics in https://github.com/Rindrics/slackmail/pull/93
+- feat: support single-user- multi-domain- usecase by @Rindrics in https://github.com/Rindrics/slackmail/pull/92
+- Revert "feat: support single-user- multi-domain- usecase" by @Rindrics in https://github.com/Rindrics/slackmail/pull/95
+- ci: resolve AWS auth error for dependabot by @Rindrics in https://github.com/Rindrics/slackmail/pull/97
+- build(deps-dev): bump @types/nodemailer from 7.0.4 to 7.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/87
+- build(deps-dev): bump @pulumi/aws from 7.15.0 to 7.16.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/90
+- build(deps): bump @aws-sdk/client-sesv2 from 3.964.0 to 3.966.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/86
+- docs: update user instructions by @Rindrics in https://github.com/Rindrics/slackmail/pull/96
+- build(deps-dev): bump @types/node from 25.0.3 to 25.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/88
+- build(deps-dev): bump @biomejs/biome from 2.3.11 to 2.3.15 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/99
+- build(deps): bump mailparser from 3.9.1 to 3.9.3 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/102
+- build(deps-dev): bump dotenv from 17.2.3 to 17.3.1 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/101
+- fix: rename ruleset slackmail -> main by @Rindrics in https://github.com/Rindrics/slackmail/pull/111
+- build(deps-dev): bump lint-staged from 16.2.7 to 16.3.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/106
+
 ## [v0.1.5](https://github.com/Rindrics/slackmail/compare/v0.1.4...v0.1.5) - 2026-01-09
 - Setup Sentry for production by @Rindrics in https://github.com/Rindrics/slackmail/pull/64
 - Handle Slack error to know what occurs by @Rindrics in https://github.com/Rindrics/slackmail/pull/66

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rindrics/slackmail",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Turn Slack into your email client - receive and send emails directly from Slack",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
This pull request is for the next release as v0.1.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* build(deps-dev): bump vite-tsconfig-paths from 6.0.3 to 6.0.4 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/89
* chore: enhance Husky hooks with comprehensive validation by @Rindrics in https://github.com/Rindrics/slackmail/pull/93
* feat: support single-user- multi-domain- usecase by @Rindrics in https://github.com/Rindrics/slackmail/pull/92
* Revert "feat: support single-user- multi-domain- usecase" by @Rindrics in https://github.com/Rindrics/slackmail/pull/95
* ci: resolve AWS auth error for dependabot by @Rindrics in https://github.com/Rindrics/slackmail/pull/97
* build(deps-dev): bump @types/nodemailer from 7.0.4 to 7.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/87
* build(deps-dev): bump @pulumi/aws from 7.15.0 to 7.16.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/90
* build(deps): bump @aws-sdk/client-sesv2 from 3.964.0 to 3.966.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/86
* docs: update user instructions by @Rindrics in https://github.com/Rindrics/slackmail/pull/96
* build(deps-dev): bump @types/node from 25.0.3 to 25.0.5 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/88
* build(deps-dev): bump @biomejs/biome from 2.3.11 to 2.3.15 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/99
* build(deps): bump mailparser from 3.9.1 to 3.9.3 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/102
* build(deps-dev): bump dotenv from 17.2.3 to 17.3.1 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/101
* fix: rename ruleset slackmail -> main by @Rindrics in https://github.com/Rindrics/slackmail/pull/111
* build(deps-dev): bump lint-staged from 16.2.7 to 16.3.0 by @dependabot[bot] in https://github.com/Rindrics/slackmail/pull/106


**Full Changelog**: https://github.com/Rindrics/slackmail/compare/v0.1.5...tagpr-from-v0.1.5